### PR TITLE
URI whitespace

### DIFF
--- a/grammar/n3.ebnf
+++ b/grammar/n3.ebnf
@@ -97,7 +97,7 @@
                                           | STRING_LITERAL_LONG_QUOTE
 
 /* borrowed from SPARQL spec, which excludes newlines and other nastiness */
-[139s] IRIREF                           ::= '<' ([^<>"{}|^`\]-[#x00-#x20] | UCHAR | WS)* '>'
+[139s] IRIREF                           ::= '<' ([^<>"{}|^`\]-[#x00-#x20] | UCHAR)* '>'
 [140s] PNAME_NS                         ::= PN_PREFIX? ':'
 [141s] PNAME_LN                         ::= PNAME_NS PN_LOCAL
 [142s] BLANK_NODE_LABEL                 ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?

--- a/grammar/n3.html
+++ b/grammar/n3.html
@@ -214,7 +214,7 @@
       <td>[139s]</td>
       <td><code>IRIREF</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">&lt;</code>" <code>(</code> <code>(</code> <code>[</code> <code class="grammar-literal">^&lt;&gt;&quot;{}|^`\</code><code>]</code>  <code>-</code> <code>[</code> <code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code>]</code> <code>)</code>  <code>|</code> <a href="#grammar-production-UCHAR">UCHAR</a> <code>|</code> <a href="#grammar-production-WS">WS</a><code>)</code> <code>*</code>  "<code class="grammar-literal">&gt;</code>"</td>
+      <td>"<code class="grammar-literal">&lt;</code>" <code>(</code> <code>(</code> <code>[</code> <code class="grammar-literal">^&lt;&gt;&quot;{}|^`\</code><code>]</code>  <code>-</code> <code>[</code> <code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code>]</code> <code>)</code>  <code>|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code>)</code> <code>*</code>  "<code class="grammar-literal">&gt;</code>"</td>
     </tr>
     <tr id="grammar-production-PNAME_NS">
       <td>[140s]</td>

--- a/tests/N3Tests/manifest.ttl
+++ b/tests/N3Tests/manifest.ttl
@@ -199,7 +199,7 @@
       :cwm_syntax_sib.n3
       :cwm_syntax_space-in-uri-ref.n3
       :cwm_syntax_space-in-uri.n3
-	  :cwm_syntax_newline-in-uri.n3
+      :cwm_syntax_newline-in-uri.n3
       :cwm_syntax_this-quantifiers-ref.n3
       :cwm_syntax_this-quantifiers-ref2.n3
       :cwm_syntax_this-quantifiers.n3
@@ -1219,12 +1219,12 @@
         mf:name        "space-in-uri-ref" .
 
 :cwm_syntax_space-in-uri.n3
-        a              test:TestN3PositiveSyntax ;
+        a              test:TestN3NegativeSyntax ;
         mf:action      <cwm_syntax/space-in-uri.n3> ;
         mf:name        "space-in-uri" .
 
 :cwm_syntax_newline-in-uri.n3
-		a              test:TestN3PositiveSyntax ;
+        a              test:TestN3NegativeSyntax ;
         mf:action      <cwm_syntax/newline-in-uri.n3> ;
         mf:name        "newline-in-uri" .
 

--- a/tests/TurtleTests/manifest.ttl
+++ b/tests/TurtleTests/manifest.ttl
@@ -1640,7 +1640,12 @@
    mf:result    <turtle-eval-lists-05.nt> ;
    .
 
-# N3 allows spaces in IRIs
+<#turtle-syntax-bad-uri-01> a rdft:TestTurtleNegativeSyntax, test:TestN3NegativeSyntax ;
+   mf:name    "turtle-syntax-bad-uri-01" ;
+   rdfs:comment "Bad IRI : space (negative test)" ;
+   rdft:approval rdft:Approved ;
+   mf:action    <turtle-syntax-bad-uri-01.ttl> ;
+   .
 
 <#turtle-syntax-bad-uri-02> a rdft:TestTurtleNegativeSyntax, test:TestN3NegativeSyntax ;
    mf:name    "turtle-syntax-bad-uri-02" ;
@@ -1750,7 +1755,7 @@
    mf:action    <turtle-syntax-bad-struct-04.ttl> ;
    .
 
-<#turtle-syntax-bad-struct-05> a rdft:TestTurtleNegativeSyntax, test:TestN3NegativeSyntax ;
+<#turtle-syntax-bad-struct-05> a rdft:TestTurtleNegativeSyntax, test:TestN3PositiveSyntax ;
    mf:name    "turtle-syntax-bad-struct-05" ;
    rdfs:comment "Turtle does not allow literals-as-predicates (negative test)" ;
    rdft:approval rdft:Approved ;
@@ -1799,7 +1804,7 @@
    mf:action    <turtle-syntax-bad-kw-04.ttl> ;
    .
 
-<#turtle-syntax-bad-kw-05> a rdft:TestTurtleNegativeSyntax, test:TestN3NegativeSyntax ;
+<#turtle-syntax-bad-kw-05> a rdft:TestTurtleNegativeSyntax, test:TestN3PositiveSyntax ;
    mf:name    "turtle-syntax-bad-kw-05" ;
    rdfs:comment "'true' cannot be used as object (negative test)" ;
    rdft:approval rdft:Approved ;
@@ -1946,7 +1951,7 @@
    mf:action    <turtle-syntax-bad-struct-14.ttl> ;
    .
 
-<#turtle-syntax-bad-struct-15> a rdft:TestTurtleNegativeSyntax, test:TestN3NegativeSyntax ;
+<#turtle-syntax-bad-struct-15> a rdft:TestTurtleNegativeSyntax, test:TestN3PositiveSyntax ;
    mf:name    "turtle-syntax-bad-struct-15" ;
    rdfs:comment "literal as predicate (negative test)" ;
    rdft:approval rdft:Approved ;


### PR DESCRIPTION
* Update EBNF to remove whitespace from IRIREF.
* Update expected test results relating to spaces in IRIREF.

For issue #45.