### PR TITLE
Fix `tests/manifest.ttl`

### DIFF
--- a/tests/manifest.ttl
+++ b/tests/manifest.ttl
@@ -10,7 +10,7 @@
     rdfs:comment "This manifest loads additional manifests for specific behavior tests" ;
     mf:include (
       <TurtleTests/manifest.ttl>
-      <N3Tests/manifest.ttl>
+      <N3Tests/manifest-parser.ttl>
       <N3Tests/manifest-reasoner.ttl>
       <N3Tests/manifest-extended.ttl>
     ) .


### PR DESCRIPTION
`tests/manifest.ttl` manifest included `N3Tests/manifest.ttl` which
does not exists.

This patch changes `tests/manifest.ttl` to include
`N3Tests/manifest-parser.ttl` instead.


Fixes https://github.com/w3c/N3/issues/98