### PR TITLE
Fixing typos in example 7 and 8 #106

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -382,7 +382,7 @@
             <td><pre class="example" id="iri-prp-list" data-transform="updateExample">
               <!--
               @prefix : <http://example.org/#> .
-              @prefix foaf: <http://xmlns.com/foaf/0.1/>
+              @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
               :spiderman foaf:name "Spiderman" ;
                 :enemyOf [ id :green-goblin ;
@@ -393,7 +393,7 @@
             <td><pre class="example" id="iri-prp-list-unfolded" data-transform="updateExample">
               <!--
               @prefix : <http://example.org/#> .
-              @prefix foaf: <http://xmlns.com/foaf/0.1/>
+              @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
               :spiderman foaf:name "Spiderman" ;
                 :enemyOf :green-goblin .


### PR DESCRIPTION
Adding a training dot after the foaf prefix declaration


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/phochste/N3/pull/107.html" title="Last updated on Oct 8, 2022, 1:22 PM UTC (5f3b351)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/N3/107/4c54f67...phochste:5f3b351.html" title="Last updated on Oct 8, 2022, 1:22 PM UTC (5f3b351)">Diff</a>