### PR TITLE
typo in example 28

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1018,7 +1018,7 @@ _:a ex:town [ ex:name "Springfield" ] .</textarea>
 
 :race :finalists ( :flash :superman :spiderman ) .
           
-{ :race ?finalists ?finalists .
+{ :race :finalists ?finalists .
   ?finalists list:iterate ( ?i ?finalist ) .
   ( ?i ". " ?finalist "<br />" ) string:concatenation ?entry
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/N3/pull/126.html" title="Last updated on Feb 8, 2023, 7:20 PM UTC (c4b1302)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/N3/126/4bc5a9b...c4b1302.html" title="Last updated on Feb 8, 2023, 7:20 PM UTC (c4b1302)">Diff</a>