### PR TITLE
fix description of datatyped literals

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -490,9 +490,9 @@ ex:green-goblin foaf:name "Green Goblin" . -->
       <p>For details on numerical syntaxes (e.g., decimals, doubles), we refer to the <a data-cite="TURTLE#abbrev">RDF
           1.1: Turtle (Section 2.5.2)</a> specification.</p>
       <p>Other literals, such as strings, but also dates, binary, octal or hex code, XML or JSON code, or other types of
-        numbers (e.g., shorts), need to be written as <b>string literals</b>. If the literal is not a string, its
-        particular datatype must be indicated using the <code>^^</code> symbol and the corresponding <dfn
-          data-cite="XMLSCHEMA11-2#built-in-datatypes">datatype IRI</dfn>. For instance:</p>
+        numbers (e.g., shorts), need to be written as <b>datatyped literals</b>. These are represented as a string, 
+        followed by the `^^` symbol and the corresponding <dfn data-cite="XMLSCHEMA11-2#built-in-datatypes">datatype IRI</dfn>.
+        (`xsd:string` is the datatype IRI for strings; this is the default and can be omitted). For instance:</p>
 
       <pre class="example nohighlight linkeditor" data-transform="updateExample"><!--
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -528,7 +528,7 @@ ex:green-goblin foaf:name "Green Goblin" . -->
         In case a language tag is given or a <code>i18n</code> "datatype" is used, the datatype <code>rdf:langString</code> is inferred.
         It is not possible to specify both a <a>datatype IRI</a> and a language tag.</p>
 
-      <p class="note">There are also other ways to describe the language tag and base direction of RDF literals, see <a href="#compoundliteral">Compound literals<a> .
+      <p class="note">There are also other ways to describe the language tag and base direction of RDF literals, see <a href="#compoundliteral">Compound literals<a>.
         Please note that these various ways are still in flux,
         see the <a href="https://github.com/w3c/rdf-star-wg/blob/main/docs/text-direction.md">"text direction"</a> discussions in the RDF-star working group.</p>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/N3/pull/154.html" title="Last updated on Mar 8, 2023, 10:02 PM UTC (62149c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/N3/154/fa16f11...62149c6.html" title="Last updated on Mar 8, 2023, 10:02 PM UTC (62149c6)">Diff</a>