### PR TITLE
Fix typo: `:weater` → `:weather`

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -933,7 +933,7 @@ _:a ex:town [ ex:name "Springfield" ] . -->
       <p>
         Hence, when the <a>premise</a> holds, then we can safely infer the <a>conclusion</a>.
         This is also referred to as <dfn data-lt="fire|firing">firing</dfn> the rule.
-        For the example above, if we state `:weather a :Raining`, then we can safely infer `:weater a :Cloudy`.
+        For the example above, if we state `:weather a :Raining`, then we can safely infer `:weather a :Cloudy`.
       </p>
 
       <p class="note">


### PR DESCRIPTION
Just a little 🧹


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Peeja/N3/pull/188.html" title="Last updated on Jun 14, 2023, 2:45 PM UTC (7b86e9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/N3/188/5fa35bf...Peeja:7b86e9a.html" title="Last updated on Jun 14, 2023, 2:45 PM UTC (7b86e9a)">Diff</a>