### PR TITLE
`<component-` → `<-`

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1455,7 +1455,7 @@ _:d a :Person. -->
         and some don't.
       </li>
       <li>
-        Representing an inverted property using the <code>&lt;components-</code> symbol. The <a
+        Representing an inverted property using the <code>&lt;-</code> symbol. The <a
           data-cite="N3#grammar">original N3 grammar</a> allowed the inverting of a property by using the
         <code>@is .. @of</code> construct. But, this construct can be unintuitive when property names are more
         verbosely


### PR DESCRIPTION
I *think* this was some kind of typo, but I may be missing context. This goes back to the initial commit in this repo, so I couldn't find its origin.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Peeja/N3/pull/189.html" title="Last updated on Jun 14, 2023, 3:18 PM UTC (e740eb0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/N3/189/5fa35bf...Peeja:e740eb0.html" title="Last updated on Jun 14, 2023, 3:18 PM UTC (e740eb0)">Diff</a>