### PR TITLE
Fix uri for prefix in the atomic elements example

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -535,7 +535,7 @@ ex:green-goblin foaf:name "Green Goblin" . -->
         date, height, and so on. Numbers (integers, decimals, and doubles) are simply represented using their
         numerical value, and booleans are represented using <code>true</code> or <code>false</code>:</p>
       <pre class="example nohighlight linkeditor" data-transform="updateExample"><!--
-@prefix : <http://example.org/elements> .
+@prefix : <http://example.org/elements#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 <http://en.wikipedia.org/wiki/Helium>


### PR DESCRIPTION
So that the IRIs generated from prefixed name are of the form `http://example.org/elements#atomicNumber`, not `http://example.org/elementsatomicNumber`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eyusupov/N3/pull/213.html" title="Last updated on Mar 19, 2024, 10:06 AM UTC (0475231)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/N3/213/1425e33...eyusupov:0475231.html" title="Last updated on Mar 19, 2024, 10:06 AM UTC (0475231)">Diff</a>