### PR TITLE
Update argument mode for list:in

### DIFF
--- a/reports/20230703/builtins.html
+++ b/reports/20230703/builtins.html
@@ -2165,7 +2165,7 @@ If there are two such numbers, then the one closest to positive infinity is retu
     Checks whether the subject is a member of the object list. 
    <p><code>true</code> if and only if <code>$o</code> is a list and <code>$s</code> is a member of that list.</p>
    <p><strong>See also</strong><br><a href="#list:member">list:member</a></p>
-   <p><strong>Schema</strong><br><code>$s-[*] list:in $o+</code></p>
+   <p><strong>Schema</strong><br><code>$s?[*] list:in $o+</code></p>
    <div class="schema_where">
     where:
     <div class="schema_datatypes"><code>$o</code>: <code>rdf:List</code></div>


### PR DESCRIPTION
It seems that `$s` is incorrectly specified as the output-only parameter, while it can be both input and output.