### PR TITLE
Fix wording in log:equalTo example

### DIFF
--- a/reports/20230703/builtins.html
+++ b/reports/20230703/builtins.html
@@ -2906,7 +2906,7 @@ Literals will be compared exactly: their datatypes must be identical (in case of
      <a href="https://editor.notation3.org/?formula=%40prefix+%3A+%3Chttp%3A%2F%2Fexample.org%2F%3E.%0A%40prefix+log%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F10%2Fswap%2Flog%23%3E+.%0A%0A%7B%0A++++%28+%22War+and+Peace%22+%22Leo+Tolstoy%22+1225+%29+log%3AequalTo+%28+%3Ftitle+%3Fauthor+%3FnumPages+%29+.%0A%7D%0A%3D%3E%0A%7B%0A++++%3Aresult+%3Ais+%3Ftitle+%2C+%3Fauthor+%2C+%3FnumPages+.%0A%7D+." target="_blank">try in editor 🚀</a>
     <div class="example" id="example-350bbe8f">
      <a class="self-link" href="#example-350bbe8f"></a> 
-     <p> Assign values from the object list to universal variables given in the subject list. 
+     <p> Assign values from the subject list to universal variables given in the object list. 
 This can be compared to "destructuring" or "unpacking" in programming languages such as JavaScript or Python.
 In contrast to those languages, however, it works in either direction in N3.
 This mechanism works because an effort is made to ensure the truthfulness of builtin statements in N3. </p>


### PR DESCRIPTION
Example 64 in log:equalTo builtin description has the subject list and object list mixed up.