### PR TITLE
Add alias dfn-path to for dfn-resource-path

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1357,7 +1357,7 @@ _:a ex:town [ ex:name "Springfield" ] . -->
     <section id='paths' class='informative'>
       <h4>Resource Paths</h4>
       <p>Similar to <a data-cite="SPARQL11-QUERY#propertypaths">SPARQL property paths</a>,
-        N3 <dfn>resource paths</dfn> concisely express paths between resources,
+        N3 <dfn data-lt="path">resource paths</dfn> concisely express paths between resources,
         when intermediary resources on the path are not relevant.
         In practice, <a>resource paths</a> are most useful in <a href="#n3rules">N3 rules</a>.</p>
 


### PR DESCRIPTION
spec/index uses `<a>path</a>` in several places.

This PR makes that link to definition "resource path".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/afs/N3/pull/223.html" title="Last updated on Dec 2, 2025, 10:06 AM UTC (07a8f1a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/N3/223/93da0ff...afs:07a8f1a.html" title="Last updated on Dec 2, 2025, 10:06 AM UTC (07a8f1a)">Diff</a>