### PR TITLE
Update api.csswg.org/bikeshed reference to spec-prod

### DIFF
--- a/useOfBuiltins/core-specs/03-development/site/spec-builtins/Makefile
+++ b/useOfBuiltins/core-specs/03-development/site/spec-builtins/Makefile
@@ -11,4 +11,4 @@ watch:
 	docker run --rm --platform linux/amd64 -v "`pwd`:/spec" -w /spec netwerkdigitaalerfgoed/bikeshed:1.7.0 sh -c "bikeshed watch"
 
 web:
-	curl -s https://api.csswg.org/bikeshed/ -F file=@index.bs -F force=1 > index.html	
+	curl -s https://www.w3.org/publications/spec-generator/ -F file=@index.bs -F type=bikeshed-spec -F die-on=nothing > index.html


### PR DESCRIPTION
This updates a `curl` command to use spec-generator instead of the CSSWG Bikeshed service, which has been discontinued.

I verified that this runs successfully, though it seems to result in a lot of additional CSS compared to the `index.html` currently in the repository.