### PR TITLE
Fixing broken layout 

### DIFF
--- a/spec/semantics.html
+++ b/spec/semantics.html
@@ -48,7 +48,6 @@
         shortName: "n3-semantics",
         xref: "web-platform",
 	      group: "n3-dev",
-        format: "markdown",
         edDraftURI: null,
         latestVersion: "https://w3c.github.io/N3/reports/20230703/semantics.html"
       };


### PR DESCRIPTION
The current rendering of the semantics specs shows literal HTML fragments at several places instead of their rendered version.

Apperently when removing some newlines in the HTML fixed one by one the issue with the broken layout. 

But, also removing the `markdown` setting in the Respec settings (without touching the HTML) did the same trick.
