### PR TITLE
Fix semantics layout. Remove 'format' property from semantics object

### DIFF
--- a/reports/20230703/semantics.html
+++ b/reports/20230703/semantics.html
@@ -48,7 +48,6 @@
         shortName: "n3-semantics",
         xref: "web-platform",
 	      group: "n3-dev",
-        format: "markdown",
         edDraftURI: null,
         latestVersion: "https://w3c.github.io/N3/reports/20230703/semantics.html"
       };


### PR DESCRIPTION
Apparently the 'markdown' setting also needs to be removed from the reports version.