### PR TITLE
Document approval status for current N3 conformance

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -14,7 +14,26 @@ In general, tests are described as Positive or Negative Syntax tests, Evaluation
 
 Tests should be run with an assumed base URI of their associated manifest, either `https://w3c.github.io/N3/tests/N3Tests` or `https://w3c.github.io/N3/tests/TurtleTests`.
 
+## Test status and current-spec conformance
+
+The manifests retain historical tests so that implementations may measure
+compatibility with older N3 dialects. Test runners reporting conformance with
+the current N3 specification should use `rdft:approval`:
+
+* `rdft:Approved`, `rdft:Proposed`, and unmarked tests are applicable to the
+  current test corpus.
+* `rdft:Rejected` tests are non-conformance compatibility tests and should be
+  reported separately rather than counted as current-spec failures.
+
+In particular, parser-corpus cases that require the legacy explicit
+quantifiers `@forAll` and `@forSome` are marked `rdft:Rejected`, because
+[explicit N3 quantifiers were removed from the current specification][quantifiers].
+The fixtures remain useful for implementations that intentionally support the
+historical syntax.
+
+[quantifiers]: https://w3c.github.io/N3/spec/#changes-since-the-team-submission
+
 # Contributing
 
 If you would like to contribute a new test or a fix to an existing test,
-please file an [issue](https://github.com/w3c/N3/issues) and/or create a [pull request](https://github.com/w3c/N3/pulls).
+please file an [issue](https://github.com/w3c-cg/N3/issues) and/or create a [pull request](https://github.com/w3c-cg/N3/pulls).


### PR DESCRIPTION
## Summary

- document how rdft:approval should be used when reporting current-spec conformance
- clarify that rdft:Rejected cases remain legacy compatibility coverage
- note that explicit @forAll/@forSome parser cases are historical because the current specification removed them
- update contribution links from w3c/N3 to w3c-cg/N3

## Motivation

The parser and extended manifests intentionally retain historical fixtures. Runners that execute every entry can report rejected legacy cases as current failures, even though these cases are already classified as rdft:Rejected. This clarifies the intended reporting without removing compatibility coverage.